### PR TITLE
Bugfix: move task notifications to lower interrupt priority

### DIFF
--- a/ble_example/Makefile
+++ b/ble_example/Makefile
@@ -89,6 +89,7 @@ SRC_FILES += \
   $(PROJ_DIR)/../nrf_common/uart_output.c \
   $(PROJ_DIR)/../nrf_common/miramesh_integration/miramesh_events.c \
   $(PROJ_DIR)/../nrf_common/miramesh_integration/miramesh_task.c \
+  $(PROJ_DIR)/../nrf_common/miramesh_integration/swi_callback_handler.c \
   $(SDK_ROOT)/components/libraries/uart/app_uart.c \
   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
   $(SDK_ROOT)/integration/nrfx/legacy/nrf_drv_uart.c \

--- a/ble_example/config/FreeRTOSConfig.h
+++ b/ble_example/config/FreeRTOSConfig.h
@@ -68,7 +68,7 @@
         60)
 #define configTOTAL_HEAP_SIZE                                                     ( \
         23 * 1024)
-#define configMAX_TASK_NAME_LEN                                                   (4)
+#define configMAX_TASK_NAME_LEN                                                   (32)
 #define configUSE_16_BIT_TICKS                                                    0
 #define configIDLE_SHOULD_YIELD                                                   1
 #define configUSE_MUTEXES                                                         1

--- a/ble_example/config/FreeRTOSConfig.h
+++ b/ble_example/config/FreeRTOSConfig.h
@@ -137,7 +137,7 @@
 
 /* The lowest interrupt priority that can be used in a call to a "set priority"
 function. */
-#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY         0xf
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY         0x7
 
 /* The highest interrupt priority that can be used by any interrupt service
 routine that makes calls to interrupt safe FreeRTOS API functions.  DO NOT CALL

--- a/ble_example/config/MiraMeshConfig.h
+++ b/ble_example/config/MiraMeshConfig.h
@@ -9,6 +9,10 @@
 #define MIRAMESH_RTC_IRQn   1
 #define MIRAMESH_SWI_IRQn   0
 
+#define SWI_CALLBACK_HANDLER_IRQn SWI3_EGU3_IRQn
+#define SWI_CALLBACK_HANDLER_IRQ_PRIO 5
+#define SWI_CALLBACK_LIST_SIZE 10
+
 /* --------------------------------------- */
 /* Define the used hardware                */
 

--- a/ble_example/network_sender_task.c
+++ b/ble_example/network_sender_task.c
@@ -11,6 +11,7 @@
 
 #include "bsp.h"
 #include "freertos_miramesh_integration.h"
+#include "swi_callback_handler.h"
 
 #define UDP_PORT 456
 #define SEND_INTERVAL 60
@@ -64,6 +65,14 @@ xTaskHandle ledTaskHandle;
 /* When to call the time_callback next time: */
 static volatile uint32_t next_tick;
 
+static void ledTask_notification_callback(void) {
+	if (ledTaskHandle != NULL) {
+        portBASE_TYPE should_yield = pdFALSE;
+        xTaskNotifyFromISR(ledTaskHandle, 1, eSetBits, &should_yield);
+        portYIELD_FROM_ISR(should_yield);
+    }
+}
+
 static void time_callback(
     mira_net_time_t tick,
     void *storage)
@@ -75,12 +84,10 @@ static void time_callback(
      *
      * Using 1.28 seconds, to keep calculation fast, and therefore latency low
      */
-    if (ledTaskHandle != NULL) {
-        portBASE_TYPE should_yield = pdFALSE;
-        bsp_board_led_invert(BSP_BOARD_LED_2);
-        xTaskNotifyFromISR(ledTaskHandle, 1, eSetBits, &should_yield);
-        portYIELD_FROM_ISR(should_yield);
-    }
+	bsp_board_led_invert(BSP_BOARD_LED_2);
+    
+	/* Invoke notification from lower priority interrupt */
+	invoke_swi_callback(ledTask_notification_callback);
 
     /* Calculate next tick */
     next_tick = (tick & 0xffffff80) + 0x00000080;
@@ -184,6 +191,8 @@ static void controller(
 void start_miramesh_app(
     void)
 {
+	register_swi_callback(ledTask_notification_callback);
+
     /*
      * Create the controller task
      */

--- a/ble_example/network_sender_task.c
+++ b/ble_example/network_sender_task.c
@@ -65,8 +65,10 @@ xTaskHandle ledTaskHandle;
 /* When to call the time_callback next time: */
 static volatile uint32_t next_tick;
 
-static void ledTask_notification_callback(void) {
-	if (ledTaskHandle != NULL) {
+static void ledTask_notification_callback(
+    void)
+{
+    if (ledTaskHandle != NULL) {
         portBASE_TYPE should_yield = pdFALSE;
         xTaskNotifyFromISR(ledTaskHandle, 1, eSetBits, &should_yield);
         portYIELD_FROM_ISR(should_yield);
@@ -84,10 +86,10 @@ static void time_callback(
      *
      * Using 1.28 seconds, to keep calculation fast, and therefore latency low
      */
-	bsp_board_led_invert(BSP_BOARD_LED_2);
-    
-	/* Invoke notification from lower priority interrupt */
-	invoke_swi_callback(ledTask_notification_callback);
+    bsp_board_led_invert(BSP_BOARD_LED_2);
+
+    /* Invoke notification from lower priority interrupt */
+    invoke_swi_callback(ledTask_notification_callback);
 
     /* Calculate next tick */
     next_tick = (tick & 0xffffff80) + 0x00000080;
@@ -139,7 +141,12 @@ static void controller(
      * Open a connection, but don't specify target address yet, which means
      * only mira_net_udp_send_to() can be used to send packets later.
      */
-    udp_connection = mira_net_udp_bind_address(NULL, NULL, 456, 456, udp_listen_callback, NULL);
+    udp_connection = mira_net_udp_bind_address(NULL,
+        NULL,
+        456,
+        456,
+        udp_listen_callback,
+        NULL);
 
     bool start_schedule = true;
     while (1) {
@@ -152,11 +159,12 @@ static void controller(
                 net_state == MIRA_NET_STATE_NOT_ASSOCIATED ? "not associated"
                 : net_state == MIRA_NET_STATE_ASSOCIATED   ? "associated"
                 : net_state == MIRA_NET_STATE_JOINED       ? "joined"
-                                                            : "UNKNOWN");
+                : "UNKNOWN");
             vTaskDelayMs(CHECK_NET_INTERVAL * 1000);
         } else {
             if (start_schedule) {
-                if (mira_net_time_get_time((uint32_t *)&next_tick) == MIRA_SUCCESS) {
+                if (mira_net_time_get_time((uint32_t *) &next_tick)
+                    == MIRA_SUCCESS) {
                     start_schedule = false;
                     mira_net_time_schedule(next_tick, time_callback, NULL);
                 } else {
@@ -177,9 +185,9 @@ static void controller(
                 * root node on the given UDP Port.
                 */
                 printf("Sending to address: %s\n",
-                        mira_net_toolkit_format_address(buffer, &net_address));
+                    mira_net_toolkit_format_address(buffer, &net_address));
                 mira_net_udp_send_to(udp_connection, &net_address, UDP_PORT,
-                                        message, strlen(message));
+                    message, strlen(message));
                 vTaskDelayMs(SEND_INTERVAL * 1000);
             }
         }
@@ -191,7 +199,7 @@ static void controller(
 void start_miramesh_app(
     void)
 {
-	register_swi_callback(ledTask_notification_callback);
+    register_swi_callback(ledTask_notification_callback);
 
     /*
      * Create the controller task

--- a/nrf_common/miramesh_integration/miramesh_task.c
+++ b/nrf_common/miramesh_integration/miramesh_task.c
@@ -17,19 +17,25 @@
 #include "MiraMeshConfig.h"
 
 #include "freertos_miramesh_integration.h"
+#include "swi_callback_handler.h"
 
 static xTaskHandle miramesh_task_handle;
 static SemaphoreHandle_t miramesh_api_lock = NULL;
 static SemaphoreHandle_t miramesh_integration_initialized = NULL;
 
-static void wake_miramesh_task_from_irq(
-    void)
-{
-    if (miramesh_task_handle != NULL) {
+static void miramesh_notification_callback(void) {
+	if (miramesh_task_handle != NULL) {
         portBASE_TYPE switch_task = pdFALSE;
         xTaskNotifyFromISR(miramesh_task_handle, 1, eSetBits, &switch_task);
         portYIELD_FROM_ISR(switch_task);
     }
+}
+
+static void wake_miramesh_task_from_irq(
+    void)
+{
+	/* Invoke notification from lower priority interrupt */
+	invoke_swi_callback(miramesh_notification_callback);
 }
 
 static void wake_miramesh_task_from_app(
@@ -143,6 +149,9 @@ void freertos_miramesh_integration_init(
         }
     };
     miramesh_config.hardware = *hardware;
+
+	swi_callback_handler_init();
+	register_swi_callback(miramesh_notification_callback);
 
     if (!nrf_sdh_is_enabled()) {
         printf("Softdevice must be enabled\n");

--- a/nrf_common/miramesh_integration/miramesh_task.c
+++ b/nrf_common/miramesh_integration/miramesh_task.c
@@ -23,8 +23,10 @@ static xTaskHandle miramesh_task_handle;
 static SemaphoreHandle_t miramesh_api_lock = NULL;
 static SemaphoreHandle_t miramesh_integration_initialized = NULL;
 
-static void miramesh_notification_callback(void) {
-	if (miramesh_task_handle != NULL) {
+static void miramesh_notification_callback(
+    void)
+{
+    if (miramesh_task_handle != NULL) {
         portBASE_TYPE switch_task = pdFALSE;
         xTaskNotifyFromISR(miramesh_task_handle, 1, eSetBits, &switch_task);
         portYIELD_FROM_ISR(switch_task);
@@ -34,8 +36,8 @@ static void miramesh_notification_callback(void) {
 static void wake_miramesh_task_from_irq(
     void)
 {
-	/* Invoke notification from lower priority interrupt */
-	invoke_swi_callback(miramesh_notification_callback);
+    /* Invoke notification from lower priority interrupt */
+    invoke_swi_callback(miramesh_notification_callback);
 }
 
 static void wake_miramesh_task_from_app(
@@ -150,8 +152,8 @@ void freertos_miramesh_integration_init(
     };
     miramesh_config.hardware = *hardware;
 
-	swi_callback_handler_init();
-	register_swi_callback(miramesh_notification_callback);
+    swi_callback_handler_init();
+    register_swi_callback(miramesh_notification_callback);
 
     if (!nrf_sdh_is_enabled()) {
         printf("Softdevice must be enabled\n");
@@ -197,7 +199,9 @@ void freertos_miramesh_integration_wait_for_ready(
 }
 
 #if configCHECK_FOR_STACK_OVERFLOW > 0
-void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
+void vApplicationStackOverflowHook(
+    TaskHandle_t xTask,
+    char *pcTaskName)
 {
     printf("Stack overflow: %s\n", pcTaskName);
 }

--- a/nrf_common/miramesh_integration/swi_callback_handler.c
+++ b/nrf_common/miramesh_integration/swi_callback_handler.c
@@ -5,7 +5,7 @@
 
 #include "swi_callback_handler.h"
 
-static void (*registered_swi_callbacks[SWI_CALLBACK_LIST_SIZE])(void);
+static swi_callback_t registered_swi_callbacks[SWI_CALLBACK_LIST_SIZE];
 static volatile int swi_callbacks_invoked[SWI_CALLBACK_LIST_SIZE];
 
 void swi_callback_handler_init(

--- a/nrf_common/miramesh_integration/swi_callback_handler.c
+++ b/nrf_common/miramesh_integration/swi_callback_handler.c
@@ -8,61 +8,62 @@
 static void (*registered_swi_callbacks[SWI_CALLBACK_LIST_SIZE])(void);
 static volatile int swi_callbacks_invoked[SWI_CALLBACK_LIST_SIZE];
 
-void swi_callback_handler_init(void) 
+void swi_callback_handler_init(
+    void)
 {
-	for (int i = 0; i < SWI_CALLBACK_LIST_SIZE; ++i) {
-		registered_swi_callbacks[i] = NULL;
-		swi_callbacks_invoked[i] = 0;
-	}
-	sd_nvic_SetPriority(SWI_CALLBACK_HANDLER_IRQn, SWI_CALLBACK_HANDLER_IRQ_PRIO);
-	sd_nvic_ClearPendingIRQ(SWI_CALLBACK_HANDLER_IRQn);
-	sd_nvic_EnableIRQ(SWI_CALLBACK_HANDLER_IRQn);
+    for (int i = 0; i < SWI_CALLBACK_LIST_SIZE; ++i) {
+        registered_swi_callbacks[i] = NULL;
+        swi_callbacks_invoked[i] = 0;
+    }
+    sd_nvic_SetPriority(SWI_CALLBACK_HANDLER_IRQn, SWI_CALLBACK_HANDLER_IRQ_PRIO);
+    sd_nvic_ClearPendingIRQ(SWI_CALLBACK_HANDLER_IRQn);
+    sd_nvic_EnableIRQ(SWI_CALLBACK_HANDLER_IRQn);
 }
 
-void invoke_swi_callback(swi_callback_t callback) 
+void invoke_swi_callback(
+    swi_callback_t callback)
 {
-	bool success = false;
-	for (int i = 0; i < SWI_CALLBACK_LIST_SIZE; ++i) {
-		if (callback == registered_swi_callbacks[i]) {
-			swi_callbacks_invoked[i] = 1;
-			success = true;
-			break;
-		}
-	}
-	if (success) {
-		sd_nvic_SetPendingIRQ(SWI_CALLBACK_HANDLER_IRQn);
-	}
-	else {
-		printf("invoke_swi_callback: callback not registered\n");
-	}
+    bool success = false;
+    for (int i = 0; i < SWI_CALLBACK_LIST_SIZE; ++i) {
+        if (callback == registered_swi_callbacks[i]) {
+            swi_callbacks_invoked[i] = 1;
+            success = true;
+            break;
+        }
+    }
+    if (success) {
+        sd_nvic_SetPendingIRQ(SWI_CALLBACK_HANDLER_IRQn);
+    } else {
+        printf("invoke_swi_callback: callback not registered\n");
+    }
 }
 
-int register_swi_callback(swi_callback_t callback) 
+int register_swi_callback(
+    swi_callback_t callback)
 {
-	for (int i = 0; i < SWI_CALLBACK_LIST_SIZE; ++i) {
-		if (callback == registered_swi_callbacks[i]) {
-			printf("register_swi_callback: callback already registered\n");
-			return -1;
-		}
-		else if (registered_swi_callbacks[i] == NULL) {
-			registered_swi_callbacks[i] = callback;
-			return 0;
-		}
-	}
-	printf("register_swi_callback: callback list full\n");
-	return -1;
+    for (int i = 0; i < SWI_CALLBACK_LIST_SIZE; ++i) {
+        if (callback == registered_swi_callbacks[i]) {
+            printf("register_swi_callback: callback already registered\n");
+            return -1;
+        } else if (registered_swi_callbacks[i] == NULL) {
+            registered_swi_callbacks[i] = callback;
+            return 0;
+        }
+    }
+    printf("register_swi_callback: callback list full\n");
+    return -1;
 }
 
 #if SWI_CALLBACK_HANDLER_IRQn == SWI3_EGU3_IRQn
 void SWI3_EGU3_IRQHandler(
     void)
 {
-	for(int i = 0; i < SWI_CALLBACK_LIST_SIZE; ++i) {
-		if (swi_callbacks_invoked[i]) {
-			swi_callbacks_invoked[i] = 0;
-			registered_swi_callbacks[i]();
-		}
-	}
+    for (int i = 0; i < SWI_CALLBACK_LIST_SIZE; ++i) {
+        if (swi_callbacks_invoked[i]) {
+            swi_callbacks_invoked[i] = 0;
+            registered_swi_callbacks[i]();
+        }
+    }
 }
 #else
 #error "SWI_CALLBACK_HANDLER_IRQn has unsupported value"

--- a/nrf_common/miramesh_integration/swi_callback_handler.c
+++ b/nrf_common/miramesh_integration/swi_callback_handler.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+
+#include "nrf_sdh.h"
+#include "nrf_nvic.h"
+
+#include "swi_callback_handler.h"
+
+static void (*registered_swi_callbacks[SWI_CALLBACK_LIST_SIZE])(void);
+static volatile int swi_callbacks_invoked[SWI_CALLBACK_LIST_SIZE];
+
+void swi_callback_handler_init(void) 
+{
+	for (int i = 0; i < SWI_CALLBACK_LIST_SIZE; ++i) {
+		registered_swi_callbacks[i] = NULL;
+		swi_callbacks_invoked[i] = 0;
+	}
+	sd_nvic_SetPriority(SWI_CALLBACK_HANDLER_IRQn, SWI_CALLBACK_HANDLER_IRQ_PRIO);
+	sd_nvic_ClearPendingIRQ(SWI_CALLBACK_HANDLER_IRQn);
+	sd_nvic_EnableIRQ(SWI_CALLBACK_HANDLER_IRQn);
+}
+
+void invoke_swi_callback(swi_callback_t callback) 
+{
+	bool success = false;
+	for (int i = 0; i < SWI_CALLBACK_LIST_SIZE; ++i) {
+		if (callback == registered_swi_callbacks[i]) {
+			swi_callbacks_invoked[i] = 1;
+			success = true;
+			break;
+		}
+	}
+	if (success) {
+		sd_nvic_SetPendingIRQ(SWI_CALLBACK_HANDLER_IRQn);
+	}
+	else {
+		printf("invoke_swi_callback: callback not registered\n");
+	}
+}
+
+int register_swi_callback(swi_callback_t callback) 
+{
+	for (int i = 0; i < SWI_CALLBACK_LIST_SIZE; ++i) {
+		if (callback == registered_swi_callbacks[i]) {
+			printf("register_swi_callback: callback already registered\n");
+			return -1;
+		}
+		else if (registered_swi_callbacks[i] == NULL) {
+			registered_swi_callbacks[i] = callback;
+			return 0;
+		}
+	}
+	printf("register_swi_callback: callback list full\n");
+	return -1;
+}
+
+#if SWI_CALLBACK_HANDLER_IRQn == SWI3_EGU3_IRQn
+void SWI3_EGU3_IRQHandler(
+    void)
+{
+	for(int i = 0; i < SWI_CALLBACK_LIST_SIZE; ++i) {
+		if (swi_callbacks_invoked[i]) {
+			swi_callbacks_invoked[i] = 0;
+			registered_swi_callbacks[i]();
+		}
+	}
+}
+#else
+#error "SWI_CALLBACK_HANDLER_IRQn has unsupported value"
+#endif

--- a/nrf_common/miramesh_integration/swi_callback_handler.h
+++ b/nrf_common/miramesh_integration/swi_callback_handler.h
@@ -11,24 +11,28 @@
  * FreeRTOS API functions from a lower interrupt priority.
  */
 
-typedef void (*swi_callback_t)(void);
+typedef void (*swi_callback_t)(
+    void);
 
 /* Initializes the SWI callback handler.
  * Clears all previously registered callbacks.
- * Sets priority for and enables SWI_CALLBACK_HANDLER_IRQn. 
+ * Sets priority for and enables SWI_CALLBACK_HANDLER_IRQn.
  */
-void swi_callback_handler_init(void);
+void swi_callback_handler_init(
+    void);
 
 /* Registers a callback to be available for invoking.
  * @retval 0: success
  * @retval -1: fail (callback list full or already registered)
  */
-int register_swi_callback(swi_callback_t callback);
+int register_swi_callback(
+    swi_callback_t callback);
 
 /* Invokes a SWI callback to be called at next SWI_CALLBACK_HANDLER_IRQn.
  * A callback must first be registered before being invoked.
  * Sets SWI_CALLBACK_HANDLER_IRQn to pending after a successful invoke.
  */
-void invoke_swi_callback(swi_callback_t callback);
+void invoke_swi_callback(
+    swi_callback_t callback);
 
 #endif

--- a/nrf_common/miramesh_integration/swi_callback_handler.h
+++ b/nrf_common/miramesh_integration/swi_callback_handler.h
@@ -1,0 +1,34 @@
+#ifndef SWI_CALLBACK_HANDLER
+#define SWI_CALLBACK_HANDLER
+
+#include "MiraMeshConfig.h"
+
+/* This module is used to trigger notifications of FreeRTOS tasks from high
+ * priority interrupts. Due to FreeRTOS being configured with a max priority of
+ * 2 in this example, one needs to ensure that higher priority interrupts do
+ * not call interrupt safe FreeRTOS API functions. This module implements a way
+ * to register and invoke callback functions that can call interrupt safe
+ * FreeRTOS API functions from a lower interrupt priority.
+ */
+
+typedef void (*swi_callback_t)(void);
+
+/* Initializes the SWI callback handler.
+ * Clears all previously registered callbacks.
+ * Sets priority for and enables SWI_CALLBACK_HANDLER_IRQn. 
+ */
+void swi_callback_handler_init(void);
+
+/* Registers a callback to be available for invoking.
+ * @retval 0: success
+ * @retval -1: fail (callback list full or already registered)
+ */
+int register_swi_callback(swi_callback_t callback);
+
+/* Invokes a SWI callback to be called at next SWI_CALLBACK_HANDLER_IRQn.
+ * A callback must first be registered before being invoked.
+ * Sets SWI_CALLBACK_HANDLER_IRQn to pending after a successful invoke.
+ */
+void invoke_swi_callback(swi_callback_t callback);
+
+#endif

--- a/nrf_common/uart_output.c
+++ b/nrf_common/uart_output.c
@@ -23,7 +23,7 @@ int _write(
     int len)
 {
     if (uart_mutex == NULL) {
-        return -1; 
+        return -1;
     }
 
     if (xSemaphoreTake(uart_mutex, portMAX_DELAY) != pdTRUE) {
@@ -31,15 +31,15 @@ int _write(
     }
 
     // TODO: This busywaits for every character.
-    for(int i = 0; i < len; ++i) {
-        while (app_uart_put(ptr[i]) != NRF_SUCCESS)
-            {}
+    for (int i = 0; i < len; ++i) {
+        while (app_uart_put(ptr[i]) != NRF_SUCCESS) {
+        }
     }
-    while (app_uart_flush())
-        {}
+    while (app_uart_flush()) {
+    }
 
     xSemaphoreGive(uart_mutex);
-    
+
     return len;
 }
 
@@ -49,20 +49,20 @@ void init_uart(
     ret_code_t err_code;
     uart_mutex = xSemaphoreCreateBinary();
 
-    app_uart_comm_params_t comm_params =
-        {
-            8, // RX pin
-            6, // TX pin
-            0,
-            0,
-            (app_uart_flow_control_t)0,
-            false,
-            NRF_UARTE_BAUDRATE_115200};
+    app_uart_comm_params_t comm_params = {
+        8,     // RX pin
+        6,     // TX pin
+        0,
+        0,
+        (app_uart_flow_control_t) 0,
+        false,
+        NRF_UARTE_BAUDRATE_115200
+    };
 
     err_code = app_uart_init(&comm_params,
-                             NULL,
-                             uart_eventhandler,
-                             APP_IRQ_PRIORITY_LOWEST);
+        NULL,
+        uart_eventhandler,
+        APP_IRQ_PRIORITY_LOWEST);
 
     APP_ERROR_CHECK(err_code);
 

--- a/nrf_network_receiver/Makefile
+++ b/nrf_network_receiver/Makefile
@@ -87,6 +87,7 @@ SRC_FILES += \
   $(PROJ_DIR)/../nrf_common/uart_output.c \
   $(PROJ_DIR)/../nrf_common/miramesh_integration/miramesh_events.c \
   $(PROJ_DIR)/../nrf_common/miramesh_integration/miramesh_task.c \
+  $(PROJ_DIR)/../nrf_common/miramesh_integration/swi_callback_handler.c \
   $(SDK_ROOT)/components/libraries/uart/app_uart.c \
   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
   $(SDK_ROOT)/integration/nrfx/legacy/nrf_drv_uart.c \

--- a/nrf_network_receiver/config/FreeRTOSConfig.h
+++ b/nrf_network_receiver/config/FreeRTOSConfig.h
@@ -68,7 +68,7 @@
         200) // XXX This was 60
 #define configTOTAL_HEAP_SIZE                                                     ( \
         23 * 1024)
-#define configMAX_TASK_NAME_LEN                                                   (4)
+#define configMAX_TASK_NAME_LEN                                                   (32)
 #define configUSE_16_BIT_TICKS                                                    0
 #define configIDLE_SHOULD_YIELD                                                   1
 #define configUSE_MUTEXES                                                         1

--- a/nrf_network_receiver/config/FreeRTOSConfig.h
+++ b/nrf_network_receiver/config/FreeRTOSConfig.h
@@ -137,7 +137,7 @@
 
 /* The lowest interrupt priority that can be used in a call to a "set priority"
 function. */
-#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY         0xf
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY         0x7
 
 /* The highest interrupt priority that can be used by any interrupt service
 routine that makes calls to interrupt safe FreeRTOS API functions.  DO NOT CALL

--- a/nrf_network_receiver/config/MiraMeshConfig.h
+++ b/nrf_network_receiver/config/MiraMeshConfig.h
@@ -9,6 +9,10 @@
 #define MIRAMESH_RTC_IRQn   2
 #define MIRAMESH_SWI_IRQn   0
 
+#define SWI_CALLBACK_HANDLER_IRQn SWI3_EGU3_IRQn
+#define SWI_CALLBACK_HANDLER_IRQ_PRIO 5
+#define SWI_CALLBACK_LIST_SIZE 10
+
 /* --------------------------------------- */
 /* Define the used hardware                */
 

--- a/nrf_network_receiver/network_receiver_task.c
+++ b/nrf_network_receiver/network_receiver_task.c
@@ -65,8 +65,10 @@ xTaskHandle ledTaskHandle;
 /* When to call the time_callback next time: */
 static volatile uint32_t next_tick;
 
-static void ledTask_notification_callback(void) {
-	if (ledTaskHandle != NULL) {
+static void ledTask_notification_callback(
+    void)
+{
+    if (ledTaskHandle != NULL) {
         portBASE_TYPE should_yield = pdFALSE;
         xTaskNotifyFromISR(ledTaskHandle, 1, eSetBits, &should_yield);
         portYIELD_FROM_ISR(should_yield);
@@ -84,10 +86,10 @@ static void time_callback(
      *
      * Using 1.28 seconds, to keep calculation fast, and therefore latency low
      */
-	bsp_board_led_invert(BSP_BOARD_LED_2);
-    
-	/* Invoke notification from lower priority interrupt */
-	invoke_swi_callback(ledTask_notification_callback);
+    bsp_board_led_invert(BSP_BOARD_LED_2);
+
+    /* Invoke notification from lower priority interrupt */
+    invoke_swi_callback(ledTask_notification_callback);
 
     /* Calculate next tick */
     next_tick = (tick & 0xffffff80) + 0x00000080;
@@ -100,8 +102,8 @@ static void ledTask(
 
     while (1) {
         ulTaskNotifyTake(1, portMAX_DELAY);
-          /* Schedule next wakeup */
-          mira_net_time_schedule(next_tick, time_callback, NULL);
+        /* Schedule next wakeup */
+        mira_net_time_schedule(next_tick, time_callback, NULL);
     }
 }
 
@@ -132,7 +134,10 @@ static void controller(
      * Open a connection, but don't specify target address yet, which means
      * only mira_net_udp_send_to() can be used to send packets later.
      */
-    udp_connection = mira_net_udp_listen_address(NULL, UDP_PORT, udp_listen_callback, NULL);
+    udp_connection = mira_net_udp_listen_address(NULL,
+        UDP_PORT,
+        udp_listen_callback,
+        NULL);
 
     while (1) {
         vTaskDelayMs(SEND_INTERVAL * 1000);
@@ -144,7 +149,7 @@ static void controller(
 void start_miramesh_app(
     void)
 {
-	register_swi_callback(ledTask_notification_callback);
+    register_swi_callback(ledTask_notification_callback);
 
     if (pdPASS != xTaskCreate(ledTask,
         (const char *const) "ledTask",

--- a/nrf_network_sender/Makefile
+++ b/nrf_network_sender/Makefile
@@ -87,6 +87,7 @@ SRC_FILES += \
   $(PROJ_DIR)/../nrf_common/uart_output.c \
   $(PROJ_DIR)/../nrf_common/miramesh_integration/miramesh_events.c \
   $(PROJ_DIR)/../nrf_common/miramesh_integration/miramesh_task.c \
+  $(PROJ_DIR)/../nrf_common/miramesh_integration/swi_callback_handler.c \
   $(SDK_ROOT)/components/libraries/uart/app_uart.c \
   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
   $(SDK_ROOT)/integration/nrfx/legacy/nrf_drv_uart.c \

--- a/nrf_network_sender/config/FreeRTOSConfig.h
+++ b/nrf_network_sender/config/FreeRTOSConfig.h
@@ -68,7 +68,7 @@
         60)
 #define configTOTAL_HEAP_SIZE                                                     ( \
         23 * 1024)
-#define configMAX_TASK_NAME_LEN                                                   (4)
+#define configMAX_TASK_NAME_LEN                                                   (32)
 #define configUSE_16_BIT_TICKS                                                    0
 #define configIDLE_SHOULD_YIELD                                                   1
 #define configUSE_MUTEXES                                                         1

--- a/nrf_network_sender/config/FreeRTOSConfig.h
+++ b/nrf_network_sender/config/FreeRTOSConfig.h
@@ -137,7 +137,7 @@
 
 /* The lowest interrupt priority that can be used in a call to a "set priority"
 function. */
-#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY         0xf
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY         0x7
 
 /* The highest interrupt priority that can be used by any interrupt service
 routine that makes calls to interrupt safe FreeRTOS API functions.  DO NOT CALL

--- a/nrf_network_sender/config/MiraMeshConfig.h
+++ b/nrf_network_sender/config/MiraMeshConfig.h
@@ -9,6 +9,10 @@
 #define MIRAMESH_RTC_IRQn   1
 #define MIRAMESH_SWI_IRQn   0
 
+#define SWI_CALLBACK_HANDLER_IRQn SWI3_EGU3_IRQn
+#define SWI_CALLBACK_HANDLER_IRQ_PRIO 5
+#define SWI_CALLBACK_LIST_SIZE 10
+
 /* --------------------------------------- */
 /* Define the used hardware                */
 

--- a/nrf_network_sender/network_sender_task.c
+++ b/nrf_network_sender/network_sender_task.c
@@ -11,6 +11,7 @@
 
 #include "bsp.h"
 #include "freertos_miramesh_integration.h"
+#include "swi_callback_handler.h"
 
 #define UDP_PORT 456
 #define SEND_INTERVAL 60
@@ -64,6 +65,14 @@ xTaskHandle ledTaskHandle;
 /* When to call the time_callback next time: */
 static volatile uint32_t next_tick;
 
+static void ledTask_notification_callback(void) {
+	if (ledTaskHandle != NULL) {
+        portBASE_TYPE should_yield = pdFALSE;
+        xTaskNotifyFromISR(ledTaskHandle, 1, eSetBits, &should_yield);
+        portYIELD_FROM_ISR(should_yield);
+    }
+}
+
 static void time_callback(
     mira_net_time_t tick,
     void *storage)
@@ -75,12 +84,10 @@ static void time_callback(
      *
      * Using 1.28 seconds, to keep calculation fast, and therefore latency low
      */
-    if (ledTaskHandle != NULL) {
-        portBASE_TYPE should_yield = pdFALSE;
-        bsp_board_led_invert(BSP_BOARD_LED_2);
-        xTaskNotifyFromISR(ledTaskHandle, 1, eSetBits, &should_yield);
-        portYIELD_FROM_ISR(should_yield);
-    }
+	bsp_board_led_invert(BSP_BOARD_LED_2);
+    
+	/* Invoke notification from lower priority interrupt */
+	invoke_swi_callback(ledTask_notification_callback);
 
     /* Calculate next tick */
     next_tick = (tick & 0xffffff80) + 0x00000080;
@@ -184,6 +191,8 @@ static void controller(
 void start_miramesh_app(
     void)
 {
+	register_swi_callback(ledTask_notification_callback);
+
     /*
      * Create the controller task
      */

--- a/nrf_network_sender/network_sender_task.c
+++ b/nrf_network_sender/network_sender_task.c
@@ -65,8 +65,10 @@ xTaskHandle ledTaskHandle;
 /* When to call the time_callback next time: */
 static volatile uint32_t next_tick;
 
-static void ledTask_notification_callback(void) {
-	if (ledTaskHandle != NULL) {
+static void ledTask_notification_callback(
+    void)
+{
+    if (ledTaskHandle != NULL) {
         portBASE_TYPE should_yield = pdFALSE;
         xTaskNotifyFromISR(ledTaskHandle, 1, eSetBits, &should_yield);
         portYIELD_FROM_ISR(should_yield);
@@ -84,10 +86,10 @@ static void time_callback(
      *
      * Using 1.28 seconds, to keep calculation fast, and therefore latency low
      */
-	bsp_board_led_invert(BSP_BOARD_LED_2);
-    
-	/* Invoke notification from lower priority interrupt */
-	invoke_swi_callback(ledTask_notification_callback);
+    bsp_board_led_invert(BSP_BOARD_LED_2);
+
+    /* Invoke notification from lower priority interrupt */
+    invoke_swi_callback(ledTask_notification_callback);
 
     /* Calculate next tick */
     next_tick = (tick & 0xffffff80) + 0x00000080;
@@ -152,11 +154,12 @@ static void controller(
                 net_state == MIRA_NET_STATE_NOT_ASSOCIATED ? "not associated"
                 : net_state == MIRA_NET_STATE_ASSOCIATED   ? "associated"
                 : net_state == MIRA_NET_STATE_JOINED       ? "joined"
-                                                            : "UNKNOWN");
+                : "UNKNOWN");
             vTaskDelayMs(CHECK_NET_INTERVAL * 1000);
         } else {
             if (start_schedule) {
-                if (mira_net_time_get_time((uint32_t *)&next_tick) == MIRA_SUCCESS) {
+                if (mira_net_time_get_time((uint32_t *) &next_tick)
+                    == MIRA_SUCCESS) {
                     start_schedule = false;
                     mira_net_time_schedule(next_tick, time_callback, NULL);
                 } else {
@@ -177,9 +180,9 @@ static void controller(
                 * root node on the given UDP Port.
                 */
                 printf("Sending to address: %s\n",
-                        mira_net_toolkit_format_address(buffer, &net_address));
+                    mira_net_toolkit_format_address(buffer, &net_address));
                 mira_net_udp_send_to(udp_connection, &net_address, UDP_PORT,
-                                        message, strlen(message));
+                    message, strlen(message));
                 vTaskDelayMs(SEND_INTERVAL * 1000);
             }
         }
@@ -191,7 +194,7 @@ static void controller(
 void start_miramesh_app(
     void)
 {
-	register_swi_callback(ledTask_notification_callback);
+    register_swi_callback(ledTask_notification_callback);
 
     /*
      * Create the controller task


### PR DESCRIPTION
Due to interrupts with higher priority than max priority configured for FreeRTOS (prio 2) calling interrupt safe FreeRTOS API functions, a node would hang after couple of hours runtime due to a corrupted task list pointer when performing a task switch. 

This change introduces a way to mitigate calling interrupt safe FreeRTOS API functions directly from high prio interrupts. The change introduces a software interrupt (SWI) callback handler, where users can register and invoke callbacks that are called from a lower priority interrupt. So instead of the high prio interrupt calling an interrupt safe FreeRTOS function directly, it instead invokes a callback which calls the API function. The IRQ for the SWI that actually calls the callback is set to pending after a successful invoke. 

NOTE: when talking about priority here, lower numerical values means higher priority (ARM nomenclature).